### PR TITLE
Relative img paths

### DIFF
--- a/app/assets/stylesheets/colorbox-rails/colorbox-rails.css
+++ b/app/assets/stylesheets/colorbox-rails/colorbox-rails.css
@@ -18,16 +18,16 @@
     Change the following styles to modify the appearance of ColorBox.  They are
     ordered & tabbed in a way that represents the nesting of the generated HTML.
 */
-#cboxOverlay{background:url(overlay.png) repeat 0 0;}
+#cboxOverlay{background:url(colorbox-rails/overlay.png) repeat 0 0;}
 #colorbox{}
-    #cboxTopLeft{width:21px; height:21px; background:url(controls.png) no-repeat -101px 0;}
-    #cboxTopRight{width:21px; height:21px; background:url(controls.png) no-repeat -130px 0;}
-    #cboxBottomLeft{width:21px; height:21px; background:url(controls.png) no-repeat -101px -29px;}
-    #cboxBottomRight{width:21px; height:21px; background:url(controls.png) no-repeat -130px -29px;}
-    #cboxMiddleLeft{width:21px; background:url(controls.png) left top repeat-y;}
-    #cboxMiddleRight{width:21px; background:url(controls.png) right top repeat-y;}
-    #cboxTopCenter{height:21px; background:url(border.png) 0 0 repeat-x;}
-    #cboxBottomCenter{height:21px; background:url(border.png) 0 -29px repeat-x;}
+    #cboxTopLeft{width:21px; height:21px; background:url(colorbox-rails/controls.png) no-repeat -101px 0;}
+    #cboxTopRight{width:21px; height:21px; background:url(colorbox-rails/controls.png) no-repeat -130px 0;}
+    #cboxBottomLeft{width:21px; height:21px; background:url(colorbox-rails/controls.png) no-repeat -101px -29px;}
+    #cboxBottomRight{width:21px; height:21px; background:url(colorbox-rails/controls.png) no-repeat -130px -29px;}
+    #cboxMiddleLeft{width:21px; background:url(colorbox-rails/controls.png) left top repeat-y;}
+    #cboxMiddleRight{width:21px; background:url(colorbox-rails/controls.png) right top repeat-y;}
+    #cboxTopCenter{height:21px; background:url(colorbox-rails/border.png) 0 0 repeat-x;}
+    #cboxBottomCenter{height:21px; background:url(colorbox-rails/border.png) 0 -29px repeat-x;}
     #cboxContent{background:#fff; overflow:hidden;}
         .cboxIframe{background:#fff;}
         #cboxError{padding:50px; border:1px solid #ccc;}
@@ -35,13 +35,13 @@
         #cboxTitle{position:absolute; bottom:4px; left:0; text-align:center; width:100%; color:#949494;}
         #cboxCurrent{position:absolute; bottom:4px; left:58px; color:#949494;}
         #cboxSlideshow{position:absolute; bottom:4px; right:30px; color:#0092ef;}
-        #cboxPrevious{position:absolute; bottom:0; left:0; background:url(controls.png) no-repeat -75px 0; width:25px; height:25px; text-indent:-9999px;}
+        #cboxPrevious{position:absolute; bottom:0; left:0; background:url(colorbox-rails/controls.png) no-repeat -75px 0; width:25px; height:25px; text-indent:-9999px;}
         #cboxPrevious:hover{background-position:-75px -25px;}
-        #cboxNext{position:absolute; bottom:0; left:27px; background:url(controls.png) no-repeat -50px 0; width:25px; height:25px; text-indent:-9999px;}
+        #cboxNext{position:absolute; bottom:0; left:27px; background:url(colorbox-rails/controls.png) no-repeat -50px 0; width:25px; height:25px; text-indent:-9999px;}
         #cboxNext:hover{background-position:-50px -25px;}
-        #cboxLoadingOverlay{background:url(loading_background.png) no-repeat center center;}
-        #cboxLoadingGraphic{background:url(loading.gif) no-repeat center center;}
-        #cboxClose{position:absolute; bottom:0; right:0; background:url(controls.png) no-repeat -25px 0; width:25px; height:25px; text-indent:-9999px;}
+        #cboxLoadingOverlay{background:url(colorbox-rails/loading_background.png) no-repeat center center;}
+        #cboxLoadingGraphic{background:url(colorbox-rails/loading.gif) no-repeat center center;}
+        #cboxClose{position:absolute; bottom:0; right:0; background:url(colorbox-rails/controls.png) no-repeat -25px 0; width:25px; height:25px; text-indent:-9999px;}
         #cboxClose:hover{background-position:-25px -25px;}
 
 /*
@@ -64,14 +64,14 @@
   The following provides PNG transparency support for IE6
   Feel free to remove this and the /ie6/ directory if you have dropped IE6 support.
 */
-.cboxIE6 #cboxTopLeft{background:url(ie6/borderTopLeft.png);}
-.cboxIE6 #cboxTopCenter{background:url(ie6/borderTopCenter.png);}
-.cboxIE6 #cboxTopRight{background:url(ie6/borderTopRight.png);}
-.cboxIE6 #cboxBottomLeft{background:url(ie6/borderBottomLeft.png);}
-.cboxIE6 #cboxBottomCenter{background:url(ie6/borderBottomCenter.png);}
-.cboxIE6 #cboxBottomRight{background:url(ie6/borderBottomRight.png);}
-.cboxIE6 #cboxMiddleLeft{background:url(ie6/borderMiddleLeft.png);}
-.cboxIE6 #cboxMiddleRight{background:url(ie6/borderMiddleRight.png);}
+.cboxIE6 #cboxTopLeft{background:url(colorbox-rails/ie6/borderTopLeft.png);}
+.cboxIE6 #cboxTopCenter{background:url(colorbox-rails/ie6/borderTopCenter.png);}
+.cboxIE6 #cboxTopRight{background:url(colorbox-rails/ie6/borderTopRight.png);}
+.cboxIE6 #cboxBottomLeft{background:url(colorbox-rails/ie6/borderBottomLeft.png);}
+.cboxIE6 #cboxBottomCenter{background:url(colorbox-rails/ie6/borderBottomCenter.png);}
+.cboxIE6 #cboxBottomRight{background:url(colorbox-rails/ie6/borderBottomRight.png);}
+.cboxIE6 #cboxMiddleLeft{background:url(colorbox-rails/ie6/borderMiddleLeft.png);}
+.cboxIE6 #cboxMiddleRight{background:url(colorbox-rails/ie6/borderMiddleRight.png);}
 
 .cboxIE6 #cboxTopLeft,
 .cboxIE6 #cboxTopCenter,

--- a/lib/colorbox-rails/version.rb
+++ b/lib/colorbox-rails/version.rb
@@ -1,3 +1,3 @@
 module ColorboxRails
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end


### PR DESCRIPTION
Doesn't CSS need colorbox-rails directory for image urls? Images weren't loading for me in rails 3.1.3 until I added this.
