### PR TITLE
Add button style reset code in case the user forgets to do so.

### DIFF
--- a/app/assets/stylesheets/colorbox-rails/colorbox-rails.css.erb
+++ b/app/assets/stylesheets/colorbox-rails/colorbox-rails.css.erb
@@ -13,7 +13,7 @@
 .cboxPhoto{float:left; margin:auto; border:0; display:block;}
 .cboxIframe{width:100%; height:100%; display:block; border:0;}
 
-/* 
+/*
     User Style:
     Change the following styles to modify the appearance of ColorBox.  They are
     ordered & tabbed in a way that represents the nesting of the generated HTML.
@@ -82,4 +82,11 @@
 .cboxIE6 #cboxMiddleLeft,
 .cboxIE6 #cboxMiddleRight {
     _behavior: expression(this.src = this.src ? this.src : this.currentStyle.backgroundImage.split('"')[1], this.style.background = "none", this.style.filter = "progid:DXImageTransform.Microsoft.AlphaImageLoader(src=" + this.src + ", sizingMethod='scale')");
+}
+/*
+  If the user's reset stylescript fails to remove the button shadows,
+  next & previous buttons will look ugly. Make sure we remove the sdahows.
+*/
+#cboxContent button {
+    border: none;
 }


### PR DESCRIPTION
If the user does not reset the default browser styling for buttons, the next and previous buttons will be ugly, because they will have shadows drawn right through the buttons.

The fact that this happens violates the principle of least astonishment, especially for Rails users who expect to be done after adding colorbox-rails to the Gemfile. And even more so if the Rails user is not a CSS guru :-)

This post pointed me in the right direction: http://community.sitepoint.com/t/gray-borders-around-controls-in-colorbox/27750

This pull request fixes the aestetics for sites that do not reset button shadows wholesale.
